### PR TITLE
The destroy was causing an endless loop by trying to clear and destroy the selected element over and over.

### DIFF
--- a/src/js/kidoju.widgets.propertygrid.js
+++ b/src/js/kidoju.widgets.propertygrid.js
@@ -433,7 +433,10 @@
                 var that = this;
                 that._removeValidator();
                 kendo.unbind(that.element);
-                kendo.destroy(that.element);
+				
+				var childElements = that.element.children();
+				
+                kendo.destroy(childElements);
                 that.element.find('*').off();
                 // clear element
                 that.element


### PR DESCRIPTION
If kendo.destroy or if angular/kendo is tearing down the components, an infinite loop can occur that repeats destroy and clear in its callstack.